### PR TITLE
Update GitHub link for RAT project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you use this codebase in your projects, please include appropriate credits:
 
 ```plaintext
 This project uses RAT (Retrieval Augmented Thinking) by Skirano
-GitHub: https://github.com/yourusername/rat
+GitHub: https://github.com/Doriandarko/RAT-retrieval-augmented-thinking
 ```
 ---
 


### PR DESCRIPTION
Fix incorrect GitHub repository URL in the README's license credits section.
